### PR TITLE
Add support for additional image tags in s2i, fixes #3

### DIFF
--- a/s2i/action.yml
+++ b/s2i/action.yml
@@ -32,6 +32,11 @@ inputs:
   image_push_password:
     description: 'the password to use for pushing the built image'
     required: true
+  image_tags:
+    description: 'tag the image with additional tags'
+    default: 'latest'
+    required: false
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -45,3 +50,4 @@ runs:
     - ${{ inputs.image_push_registry }}
     - ${{ inputs.image_push_username }}
     - ${{ inputs.image_push_password }}
+    - ${{ inputs.image_tags }}

--- a/s2i/action.yml
+++ b/s2i/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: 'the password to use for pushing the built image'
     required: true
   image_tags:
-    description: 'tag the image with additional tags'
+    description: 'tag the image with additional tags (comma separated)'
     default: 'latest'
     required: false
 

--- a/s2i/entrypoint.sh
+++ b/s2i/entrypoint.sh
@@ -12,7 +12,7 @@ IMAGE_PULL_PASSWORD=$6
 IMAGE_PUSH_REGISTRY=$7
 IMAGE_PUSH_USERNAME=$8
 IMAGE_PUSH_PASSWORD=$9
-IMAGE_TAGS=$10
+IMAGE_TAGS=${10}
 
 if [ -z $IMAGE_PULL_USERNAME ]; then
     echo "Skipping login for image pull - username not set."

--- a/s2i/entrypoint.sh
+++ b/s2i/entrypoint.sh
@@ -32,6 +32,8 @@ docker push "${OUTPUT_IMAGE}"
 echo "TAGS: ${IMAGE_TAGS}"
 for tag in $(echo $IMAGE_TAGS|sed -e 's/ //g' -e 's/,/ /g'); do
   TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
+  echo "Tagging ${OUTPUT_IMAGE} as ${TAG}"
   docker tag $OUTPUT_IMAGE $TAG
-  docker push $LATEST_TAG
+  echo "Pushing ${TAG}"
+  docker push $TAG
 done

--- a/s2i/entrypoint.sh
+++ b/s2i/entrypoint.sh
@@ -1,17 +1,36 @@
 #!/bin/bash
 
 set -e
-if [ "$5" = "" ]; then
+
+# Set named vars
+SRC=$1
+BASE=$2
+OUTPUT_IMAGE=$3
+IMAGE_PULL_REGISTRY=$4
+IMAGE_PULL_USERNAME=$5
+IMAGE_PULL_PASSWORD=$6
+IMAGE_PUSH_REGISTRY=$7
+IMAGE_PUSH_USERNAME=$8
+IMAGE_PUSH_PASSWORD=$9
+IMAGE_TAGS=$10
+
+if [ -z $IMAGE_PULL_USERNAME ]; then
     echo "Skipping login for image pull - username not set."
 else
     echo "Credentials for builder image registry detected - logging in."
-    echo "$6" | docker login "$4" --username "$5" --password-stdin
+    echo "${IMAGE_PULL_PASSWORD}" | docker login "${IMAGE_PULL_REGISTRY}" --username "${IMAGE_PULL_USERNAME}" --password-stdin
 fi
 # We will always need to login to the registry we intend to push to
-echo "$9" | docker login "$7" --username "$8" --password-stdin
+echo "${IMAGE_PUSH_PASSWORD}" | docker login "${IMAGE_PUSH_REGISTRY}" --username "${IMAGE_PUSH_USERNAME}" --password-stdin
 # Grab builder image
-docker pull "$2"
+docker pull "${BASE}"
 # Build
-s2i build "$1" "$2" "$3"
+s2i build "${SRC}" "${BASE}" "${OUTPUT_IMAGE}"
 # Push to output registry
-docker push "$3"
+docker push "${OUTPUT_IMAGE}"
+# Add additional tags
+for tag in $IMAGE_TAGS; do
+  TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
+  docker tag $OUTPUT_IMAGE $TAG
+  docker push $LATEST_TAG
+done

--- a/s2i/entrypoint.sh
+++ b/s2i/entrypoint.sh
@@ -29,8 +29,9 @@ s2i build "${SRC}" "${BASE}" "${OUTPUT_IMAGE}"
 # Push to output registry
 docker push "${OUTPUT_IMAGE}"
 # Add additional tags
-for tag in $IMAGE_TAGS; do
-  TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
-  docker tag $OUTPUT_IMAGE $TAG
-  docker push $LATEST_TAG
-done
+echo "TAGS: ${IMAGE_TAGS}"
+#for tag in $IMAGE_TAGS; do
+#  TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
+#  docker tag $OUTPUT_IMAGE $TAG
+#  docker push $LATEST_TAG
+#done

--- a/s2i/entrypoint.sh
+++ b/s2i/entrypoint.sh
@@ -29,7 +29,7 @@ s2i build "${SRC}" "${BASE}" "${OUTPUT_IMAGE}"
 # Push to output registry
 docker push "${OUTPUT_IMAGE}"
 # Add additional tags
-echo "TAGS: ${IMAGE_TAGS}"
+echo "Adding additional tags"
 for tag in $(echo $IMAGE_TAGS|sed -e 's/ //g' -e 's/,/ /g'); do
   TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
   echo "Tagging ${OUTPUT_IMAGE} as ${TAG}"

--- a/s2i/entrypoint.sh
+++ b/s2i/entrypoint.sh
@@ -30,8 +30,8 @@ s2i build "${SRC}" "${BASE}" "${OUTPUT_IMAGE}"
 docker push "${OUTPUT_IMAGE}"
 # Add additional tags
 echo "TAGS: ${IMAGE_TAGS}"
-#for tag in $IMAGE_TAGS; do
-#  TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
-#  docker tag $OUTPUT_IMAGE $TAG
-#  docker push $LATEST_TAG
-#done
+for tag in $(echo $IMAGE_TAGS|sed -e 's/ //g' -e 's/,/ /g'); do
+  TAG=$(echo $OUTPUT_IMAGE|cut -d: -f1):${tag}
+  docker tag $OUTPUT_IMAGE $TAG
+  docker push $LATEST_TAG
+done


### PR DESCRIPTION
This lets you add additional tags to your image.
It also adds named input variables to `entrypoint.sh` to help understand the variables.

```
Tagging quay.io/pabrahamsson/argo-cd-bridge:ffe5ee14c63b069e4c3294f40e5923eb2e486420 as quay.io/pabrahamsson/argo-cd-bridge:latest
Pushing quay.io/pabrahamsson/argo-cd-bridge:latest
The push refers to repository [quay.io/pabrahamsson/argo-cd-bridge]
4db8ceb8519c: Preparing
0673f18b23fc: Preparing
84ecc5257b90: Preparing
74d760a83a4b: Preparing
c7fbe90ae90e: Preparing
35817540a17b: Preparing
35817540a17b: Waiting
0673f18b23fc: Layer already exists
4db8ceb8519c: Layer already exists
74d760a83a4b: Layer already exists
84ecc5257b90: Layer already exists
c7fbe90ae90e: Layer already exists
35817540a17b: Layer already exists
latest: digest: sha256:1eeb557364d298329e2a17561ce6628f7c2730fcf981089c0e11411b9d5b26f4 size: 1581
```