### PR TITLE
Added github-dispatches

### DIFF
--- a/.github/workflows/github-dispatches.yaml
+++ b/.github/workflows/github-dispatches.yaml
@@ -1,0 +1,24 @@
+name: Test github-dispatches
+
+on:
+  push:
+    paths:
+      - .github/workflows/github-dispatches.yaml
+      - github-dispatches/**
+  pull_request:
+    paths:
+      - .github/workflows/github-dispatches.yaml
+      - github-dispatches/**
+
+jobs:
+  github-dispatches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: github-dispatches
+        uses: ./github-dispatches
+        with:
+          username_token: ${{ secrets.REPO_TOKEN }}
+          repo_array: '[{"url":"redhat-cop/rego-policies","event_type":"Trigger","client_payload":{"from-action":"github-dispatches"}}]'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains:
 
 ### Actions
 - [confbatstest](/confbatstest)
+- [github-dispatches](/github-dispatches)
 - [redhat-csp-download](/redhat-csp-download)
 - [s2i](/s2i)
 

--- a/github-dispatches/Dockerfile
+++ b/github-dispatches/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+
+LABEL version="1.0.0"
+LABEL repository="http://github.com/redhat-cop/github-actions"
+LABEL homepage="http://github.com/redhat-cop/github-actions/github-dispatches"
+LABEL maintainer="Red Hat CoP"
+LABEL "com.github.actions.name"="github-dispatches"
+LABEL "com.github.actions.description"="Triggers a GitHub CI dispatches event."
+LABEL "com.github.actions.branding.icon"="monitor"
+LABEL "com.github.actions.branding.color"="purple"
+
+RUN microdnf install --assumeyes --nodocs curl && \
+    microdnf clean all && \
+    curl --version
+
+RUN export JQ_VERSION=1.6 && \
+    curl -L -o /tmp/jq-linux64 https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
+    chmod +x /tmp/jq-linux64 && \
+    ln -s /tmp/jq-linux64 /usr/local/bin/jq && \
+    jq --version
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/github-dispatches/README.md
+++ b/github-dispatches/README.md
@@ -1,0 +1,15 @@
+![Test github-dispatches](https://github.com/redhat-cop/github-actions/workflows/Test%20github-dispatches/badge.svg)
+
+# github-dispatches GitHub Action
+
+This action triggers a GitHub CI [dispatches event](https://blog.marcnuri.com/triggering-github-actions-across-different-repositories).
+
+## Usage
+
+```yaml
+    - name: github-dispatches
+      uses: ./github-dispatches
+      with:
+        username_token: ${{ secrets.REPO_TOKEN }}
+        repo_array: '[{"url":"owner/repo","event_type":"Triggered","client_payload":{"customField":"customValue"}}]'
+```

--- a/github-dispatches/action.yml
+++ b/github-dispatches/action.yml
@@ -1,0 +1,20 @@
+name: 'github-dispatches'
+description: 'Triggers a GitHub CI dispatches event.'
+author: 'Red Hat CoP'
+branding:
+  icon: monitor
+  color: purple
+inputs:
+  repo_array:
+    description: "JSON array of repos to trigger"
+    required: true
+  username_token:
+    description: "Personal GitHub access token in the form of 'username:token' which has 'repo' access"
+    required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.repo_array }}
+    - ${{ inputs.username_token }}

--- a/github-dispatches/entrypoint.sh
+++ b/github-dispatches/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+exec_dispatches() {
+  local REPOS="${1}"
+  local USRNAME_TOKEN="${2}"
+
+  echo "${REPOS}" | jq -e "." >/dev/null 2>&1
+  local jq_code=$?
+  if [[ "${jq_code}" -ne 0 ]]; then
+    echo "${jq_code} : Failed to parse 'repo_array' JSON. Failing"
+    echo "${REPOS}"
+    exit 1
+  fi
+
+  if [[ -z "${USRNAME_TOKEN}" ]]; then
+    echo "USRNAME_TOKEN is empty. Skipping."
+    exit 0
+  fi
+
+  for row in $(echo "${REPOS}" | jq -c ".[]"); do
+    _jq() {
+      echo "${row}" | jq -r -c "${1}"
+    }
+
+    echo "Attempting to trigger: ${row}"
+
+    url=$(_jq ".url")
+    data=$(_jq "{event_type: .event_type, client_payload: .client_payload}")
+
+    HTTP_STATUS=$(curl --silent --show-error --request POST "https://api.github.com/repos/${url}/dispatches" \
+      -o /dev/null -w "%{http_code}" \
+      --header "Accept: application/vnd.github.everest-preview+json" \
+      --user "${USRNAME_TOKEN}" \
+      --data "${data}")
+
+    if [[ "${HTTP_STATUS}" -ne 204 ]] ; then
+      echo "Expected 204, got ${HTTP_STATUS} status code. Failng."
+      exit 1
+    fi
+
+    echo "Completed: ${HTTP_STATUS}"
+  done
+}
+
+exec_dispatches "${1}" "${2}"

--- a/redhat-csp-download/README.md
+++ b/redhat-csp-download/README.md
@@ -1,3 +1,5 @@
+![Test redhat-csp-download](https://github.com/redhat-cop/github-actions/workflows/Test%20redhat-csp-download/badge.svg)
+
 # redhat-csp-download GitHub Action
 
 This action uses [redhat-csp-download](https://github.com/sabre1041/redhat-csp-download) to download resources from the Red Hat Customer Portal,


### PR DESCRIPTION
#### What is this PR About?
An action to trigger other CIs.

There are a few actions already which do something similar, but they dont support a list, i.e.: you'd need to call the action multiple times if you wanted to trigger multiple downstream repos.

i.e.:
- https://github.com/marketplace/actions/webhook-trigger
- https://github.com/mvasigh/dispatch-action

#### How do we test this?
See test action output.

cc: @redhat-cop/github-actions
