### PR TITLE
added check to stop dependabot running the push

### DIFF
--- a/.github/workflows/confbatstest-build.yaml
+++ b/.github/workflows/confbatstest-build.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       context: confbatstest
       image_name: confbatstest
+      branch_name: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +38,7 @@ jobs:
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 
       - name: Push to ghcr.io
+        if: ${{ env.branch_name == 'master' }} # Stops push running when dependabot creates a PR, which fails due to token
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build_image.outputs.image }}

--- a/.github/workflows/github-dispatches-build.yaml
+++ b/.github/workflows/github-dispatches-build.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       context: github-dispatches
       image_name: github-dispatches
+      branch_name: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +38,7 @@ jobs:
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 
       - name: Push to ghcr.io
+        if: ${{ env.branch_name == 'master' }} # Stops push running when dependabot creates a PR, which fails due to token
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build_image.outputs.image }}

--- a/.github/workflows/kyverno-cli-build.yaml
+++ b/.github/workflows/kyverno-cli-build.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       context: kyverno-cli
       image_name: kyverno-cli
+      branch_name: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +38,7 @@ jobs:
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 
       - name: Push to ghcr.io
+        if: ${{ env.branch_name == 'master' }} # Stops push running when dependabot creates a PR, which fails due to token
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build_image.outputs.image }}

--- a/.github/workflows/redhat-csp-download-build.yaml
+++ b/.github/workflows/redhat-csp-download-build.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       context: redhat-csp-download
       image_name: redhat-csp-download
+      branch_name: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +38,7 @@ jobs:
           tags: "${{ steps.image_tags.outputs.IMAGE_TAGS }}"
 
       - name: Push to ghcr.io
+        if: ${{ env.branch_name == 'master' }} # Stops push running when dependabot creates a PR, which fails due to token
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build_image.outputs.image }}


### PR DESCRIPTION
#### What is this PR About?
this should stop the `push` actions failing when someone opens a PR within the repo, i.e.: dependabot

#### How do we test this?


cc: @redhat-cop/github-actions
