### PR TITLE
FIX: update confbatstest to golang 1.17

### DIFF
--- a/confbatstest/Dockerfile_build
+++ b/confbatstest/Dockerfile_build
@@ -1,5 +1,5 @@
 # Builder image for go
-FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS go-builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7 AS go-builder
 RUN GOBIN=/tmp/go-bin go install github.com/plexsystems/konstraint@latest && \
     /tmp/go-bin/konstraint --help
 


### PR DESCRIPTION
#### What is this PR About?
Allow the confbatstest image to build without error because `konstraint` requires Go 1.17. See conversation in #65 for more details.

#### How do we test this?
CI goes :heavy_check_mark: 

cc: @redhat-cop/github-actions
