### PR TITLE
Switch to ubi9 images

### DIFF
--- a/chart-repo-pr-action/Dockerfile
+++ b/chart-repo-pr-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.0.0
 
 ## According to the GH Actions doc, the user must run as root
 ## https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user

--- a/confbatstest/Dockerfile_build
+++ b/confbatstest/Dockerfile_build
@@ -1,10 +1,10 @@
 # Builder image for go
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7 AS go-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.17.7 AS go-builder
 RUN GOBIN=/tmp/go-bin go install github.com/plexsystems/konstraint@latest && \
     /tmp/go-bin/konstraint --help
 
 # Builder image
-FROM registry.access.redhat.com/ubi8/ubi:8.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.0.0 AS builder
 
 RUN export HELM_VERSION=3.7.2 && \
     curl -L -o /tmp/helm-v${HELM_VERSION}-linux-amd64.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
@@ -38,7 +38,7 @@ RUN export KUBEVAL_VERSION=latest && \
     /tmp/kubeval --version
 
 # Runnable image
-FROM registry.access.redhat.com/ubi8/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:1
 
 LABEL version="1.8.0"
 LABEL repository="http://github.com/redhat-cop/github-actions"

--- a/github-dispatches/Dockerfile_build
+++ b/github-dispatches/Dockerfile_build
@@ -1,5 +1,5 @@
 # Builder image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.0.0 AS builder
 
 RUN export JQ_VERSION=1.6 && \
     curl -L -o /tmp/jq-linux64 https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
@@ -7,7 +7,7 @@ RUN export JQ_VERSION=1.6 && \
     /tmp/jq-linux64 --version
 
 # Runnable image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.0.0
 
 LABEL version="1.2.0"
 LABEL repository="http://github.com/redhat-cop/github-actions"

--- a/kyverno-cli/Dockerfile_build
+++ b/kyverno-cli/Dockerfile_build
@@ -1,5 +1,5 @@
 # Builder image
-FROM registry.access.redhat.com/ubi8/ubi:8.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.0.0 AS builder
 
 RUN export HELM_VERSION=3.7.2 && \
     curl -L -o /tmp/helm-v${HELM_VERSION}-linux-amd64.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
@@ -23,7 +23,7 @@ RUN export KYVERNO_VERSION=v1.4.2 && \
     /tmp/kyverno --help
 
 # Runnable image
-FROM registry.access.redhat.com/ubi8/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:1
 
 LABEL version="1.1.0"
 LABEL repository="http://github.com/redhat-cop/github-actions"

--- a/redhat-csp-download/Dockerfile_build
+++ b/redhat-csp-download/Dockerfile_build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:1
 
 LABEL version="1.3.0"
 LABEL repository="http://github.com/redhat-cop/github-actions"

--- a/set-helm-version/Dockerfile
+++ b/set-helm-version/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:1
 
 LABEL version="1.1.0"
 LABEL repository="http://github.com/redhat-cop/github-actions"


### PR DESCRIPTION
#### What is this PR About?
Update to UBI 9 now that RHEL 9 is GA and corresponding UBI images are available.

#### How do we test this?
CI goes :heavy_check_mark: (except for s2i)

cc: @redhat-cop/github-actions
