### PR TITLE
changed to new way of doing output

### DIFF
--- a/get-image-version/action.yml
+++ b/get-image-version/action.yml
@@ -35,6 +35,7 @@ runs:
             TAGS+=("git-${BASH_REMATCH[1]}")
         fi
 
-        echo "::set-output name=VERSION::$(echo $VERSION)"
-        echo "::set-output name=MINOR_VERSION::$(echo ${VERSION%.*})"
-        echo "::set-output name=IMAGE_TAGS::$(echo ${TAGS[*]})"
+        echo "VERSION=$(echo $VERSION)" >> $GITHUB_OUTPUT
+        echo "MINOR_VERSION=$(echo ${VERSION%.*})" >> $GITHUB_OUTPUT
+        echo "IMAGE_TAGS=$(echo ${TAGS[*]})" >> $GITHUB_OUTPUT
+        


### PR DESCRIPTION
#### What is this PR About?
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

#### How do we test this?
green ci

cc: @redhat-cop/github-actions
